### PR TITLE
mpv: Update deprecated flag.

### DIFF
--- a/mpv.py
+++ b/mpv.py
@@ -94,7 +94,7 @@ class MPVBase:
         """
         self.argv = [self.executable]
         self.argv += self.default_argv
-        self.argv += ["--input-unix-socket", self._sock_filename]
+        self.argv += ["--input-ipc-server", self._sock_filename]
         if self.window_id is not None:
             self.argv += ["--wid", str(self.window_id)]
 


### PR DESCRIPTION
First of all, thank you for this interface! I'm currently embedding it in a script
to connect a Pandora stream to mpv.

This PR introduces one change:

`--input-unix-socket` has been replaced with `--input-ipc-server` in mpv.
The former might be removed in future versions.
