### PR TITLE
use distutils.spawn.find_executable() to locate mpv binary

### DIFF
--- a/mpv.py
+++ b/mpv.py
@@ -35,6 +35,7 @@ import threading
 import subprocess
 import inspect
 
+from distutils.spawn import find_executable
 from queue import Queue, Empty, Full
 
 
@@ -59,7 +60,7 @@ class MPVBase:
        based JSON IPC.
     """
 
-    executable = "/usr/bin/mpv"
+    executable = find_executable("mpv")
 
     default_argv = [
         "--idle",


### PR DESCRIPTION
rather than a hardcoded POSIX-only value this should now get it working on Windows and macOS (where mpv is commonly installed under /usr/local/bin by the Homebrew packager)

P.S. thanks for putting this code up... hadn't seen json ipc w/ python before, interesting...